### PR TITLE
Case sensitivity for character parsing

### DIFF
--- a/parsec.el
+++ b/parsec.el
@@ -601,15 +601,14 @@
         (setq regex-str (concat regex-str "^"))))
     (concat regex-head regex-str regex-end)))
 
-(defun parsec-one-of (&rest chars)
+(defmacro parsec-one-of (&rest chars)
   "Succeed if the current character is in the supplied list of CHARS.
 Return the parsed character.
 
->  (parsec-one-of ?a ?e ?i ?o ?u)
-
-Note this function is just a wrapper of `parsec-re'.  For complicated use cases,
-consider using `parsec-re' instead."
-  (parsec-re (format "[%s]" (parsec-make-alternatives chars))))
+>  (parsec-one-of ?a ?e ?i ?o ?u)"
+  (let ((sexp '(parsec-or))
+	(parsers (mapcar (lambda (c) (list #'parsec-ch c)) chars)))
+    (append sexp parsers)))
 
 (defun parsec-none-of (&rest chars)
   "Succeed if the current character not in the supplied list of CHARS.

--- a/parsec.el
+++ b/parsec.el
@@ -548,7 +548,8 @@
   "Parse a character CH."
   (let ((next-char (char-after)))
     (if (and (not (eobp))
-             (char-equal next-char ch))
+	     (let ((case-fold-search nil)) ;; case sensitivity for char-equal
+	       (char-equal next-char ch)))
         (progn (forward-char 1)
                (char-to-string ch))
       (parsec-stop :expected (char-to-string ch)

--- a/parsec.el
+++ b/parsec.el
@@ -548,8 +548,7 @@
   "Parse a character CH."
   (let ((next-char (char-after)))
     (if (and (not (eobp))
-	     (let ((case-fold-search nil)) ;; case sensitivity for char-equal
-	       (char-equal next-char ch)))
+             (char-equal next-char ch))
         (progn (forward-char 1)
                (char-to-string ch))
       (parsec-stop :expected (char-to-string ch)


### PR DESCRIPTION
I had some issues when attempting to parse case-sensitive characters when using the `parsec-one-of` and `parsec-ch` functions. The comparisons for each of these parsers (regex in the case of `parsec-one-of`, and `char-equal` in the case of `parsec-ch`) both use the the buffer-local variable `case-fold-search` to define whether or not to make the comparison case-sensitive. Unfortunately, since the variable is buffer-local it doesn't seem possible (easily at least) to set the variable externally at the point where the parsers are constructed. Take, for example, the following case:

``` elisp
(let ((case-fold-search nil))
  (parsec-with-input "d" (parsec-one-of ?D ?e ?f ?g)))
"D"
```

The change to `case-fold-search` does not take effect here; possibly due to the lisp compilation. Either way, it seems incorrect to always use case-insensitive character comparisons as this returns a character which wasn't in the input stream.

This merge request contains some changes that I made in order to make both the `parsec-ch` and `parsec-one-of` functions case-sensitive for my uses, and figured that I would submit it in case it's a change that would be useful to consider. In it are two changes:
  1. Set `case-fold-search` in `parsec-ch` to make it case-sensitive
  2. Rewrote `parsec-one-of` as a macro that constructs the parser `(parsec-or (parsec-ch CHAR1) (parsec-ch CHAR2) ... )`. This keeps consistency in the ways that characters are parsed by always using `parsec-ch`.