### PR TITLE
Fix parsec-count

### DIFF
--- a/parsec.el
+++ b/parsec.el
@@ -899,7 +899,8 @@ Return a list of N values returned by PARSER."
   (let ((res-sym (make-symbol "results")))
     `(let (,res-sym)
        (dotimes (_ ,n ,res-sym)
-         (push ,parser ,res-sym)))))
+         (push ,parser ,res-sym))
+       (nreverse ,res-sym))))
 
 (defmacro parsec-count-as-string (n parser)
   "Parse N occurrences of PARSER.


### PR DESCRIPTION
Before

```
(parsec-with-input "2017-11-17T12:46:26+08:00"
  (parsec-count-s 4 (parsec-digit)))
     => "7102"
```

After:

```
(parsec-with-input "2017-11-17T12:46:26+08:00"
  (parsec-count-s 4 (parsec-digit)))
     => "2017"
```
