### PR TITLE
Only load cl-lib when needed

### DIFF
--- a/parsec.el
+++ b/parsec.el
@@ -501,7 +501,8 @@
 
 ;;; Code:
 
-(require 'cl-lib)
+(eval-when-compile 
+  (require 'cl-lib))
 
 (defgroup parsec nil
   "Parser combinators for Emacs Lisp"


### PR DESCRIPTION
cl-lib is only needed on compile, so only load it at that time.